### PR TITLE
✨ Feat. #37 Husky 셋업(commit-msg 컨벤션 강제)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,8 @@ Temporary Items
 # iCloud generated files
 *.icloud
 
+### git convenience ###
+# Node.js
+node_modules/
+
 # End of https://www.toptal.com/developers/gitignore/api/macos

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/bin/sh
+bash scripts/validate-commit-msg.sh "$1"

--- a/docs/commit-guide.md
+++ b/docs/commit-guide.md
@@ -1,0 +1,118 @@
+
+# 🔒 Husky 기반 커밋 메시지 검사 가이드
+
+## 📌 개요
+
+이 프로젝트는 **일관된 커밋 메시지 작성 규칙**을 강제하기 위해 [Husky](https://typicode.github.io/husky/)를 사용합니다.
+
+커밋 메시지가 정해진 형식에 맞지 않으면, **커밋이 차단되고 에러 메시지가 출력**됩니다.
+
+## 🛠 사전 준비사항
+
+| 항목         | 설명                                                                                  |
+| ---------- | ----------------------------------------------------------------------------------- |
+| Node.js    | 설치 필요. macOS는 `brew install node`, Windows는 [Node.js 공식 페이지](https://nodejs.org) 참고 |
+| Git 초기화 상태 | `.git/` 폴더가 있어야 합니다                                                                 |
+
+## 🚀 설치 방법 (최초 1회)
+
+```bash
+bash setup.sh
+```
+
+이 명령은 다음을 자동으로 수행합니다:
+
+1. Husky 설치 및 초기화
+2. `package.json`에 `prepare` 스크립트 삽입
+3. `.husky/commit-msg` 생성 및 커밋 메시지 검사 스크립트 연결
+4. 실행 권한 설정 및 검증
+
+## 📋 커밋 메시지 컨벤션 요약
+
+| 구분    | 규칙                                                                  |
+| ----- | ------------------------------------------------------------------- |
+| 제목    | `<Type>. 요약 설명` or `📝 <Type>. 요약 설명`</br>Type은 대문자로 시작. 마침표 뒤 공백 필수 |
+| 요약 길이 | 한국어 기준 30자 이내 권장 (권장사항)                                             |
+| 본문    | `Why:` 변경 이유 / `How:` 변경 방법                                         |
+
+## ✅ 커밋 메시지 예시
+
+```text
+🖍 Docs. 컴포넌트 구조 개선
+
+Why:
+- View 네이밍 통일
+
+How:
+- CycleView → CycleProgressView로 변경
+```
+
+```text
+Fix. 로그인 실패 시 예외처리 추가
+
+Why:
+- 빈 토큰에서 앱이 크래시 발생
+
+How:
+- if 조건문 보호 및 로그 출력 추가
+```
+
+## ❌ 잘못된 메시지 예시
+
+```text
+readme 업데이트
+```
+
+```text
+fix: 로그인 고침
+```
+
+이런 커밋을 시도하면 아래와 같은 메시지가 출력됩니다:
+
+```text
+❌ 제목 형식 오류:
+🔹 제목은 'Type. 요약 설명' 또는 '🖍 Type. 요약 설명' 형식이어야 합니다.
+```
+
+## 🧪 테스트 방법
+
+```bash
+git commit --allow-empty -m "README 업데이트"      # ❌ 실패 (형식 위반)
+
+git commit --allow-empty -m "Docs. 리드미 정리 완료
+
+Why:
+- 오래된 구조를 반영하고 있음
+
+How:
+- 섹션 순서 변경, UI 설명 추가
+"                                # ✅ 성공
+```
+
+## 🗑 비활성화/제거 방법 (로컬 전용)
+
+```bash
+rm .husky/commit-msg
+```
+
+> 팀원 간 규칙은 유지되므로 제거는 권장되지 않음
+
+## 📁 관련 파일 구조
+
+```
+project-root/
+├── .husky/
+│   └── commit-msg             # 실행 진입점
+├── scripts/
+│   └── validate-commit-msg.sh # 검사 스크립트 본문
+├── setup.sh                   # 자동 설치 스크립트
+├── package.json
+├── package-lock.json
+├── .gitignore
+```
+
+## 🧑‍💻 추가 자료
+
+* [Husky 공식 문서](https://typicode.github.io/husky/)
+* [Conventional Commits](https://www.conventionalcommits.org/ko/v1.0.0/)
+* [Gitmoji](https://gitmoji.dev)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "2025-c3-m9-umpahumpah",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "2025-c3-m9-umpahumpah",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "husky": "^9.1.7"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "2025-c3-m9-umpahumpah",
+  "version": "1.0.0",
+  "description": "--- marp: true theme: default paginate: true ---",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "husky install"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DeveloperAcademy-POSTECH/2025-C3-M9-UmpahUmpah.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/DeveloperAcademy-POSTECH/2025-C3-M9-UmpahUmpah/issues"
+  },
+  "homepage": "https://github.com/DeveloperAcademy-POSTECH/2025-C3-M9-UmpahUmpah#readme",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
+}

--- a/scripts/validate-commit-msg.sh
+++ b/scripts/validate-commit-msg.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+COMMIT_MSG_FILE=$1
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# ✅ 예외 커밋
+if echo "$COMMIT_MSG" | grep -qE "^(Merge pull request|README\.md 업데이트)"; then
+  exit 0
+fi
+
+# ✅ 제목 추출
+TITLE=$(echo "$COMMIT_MSG" | head -n 1)
+
+# ✅ 제목 정규식 검사 (이모지 optional, 공백 optional)
+TITLE_REGEX="^(([[:graph:]]{1,3})\s*)?[A-Z][a-zA-Z]+\. .+"
+
+if ! echo "$TITLE" | grep -Eq "$TITLE_REGEX"; then
+  echo "❌ 제목 형식 오류:"
+  echo "👉 제목은 'Type. 요약 설명' 또는 '📝 Type. 요약 설명' 형식이어야 합니다."
+  exit 1
+fi
+
+# ✅ 제목 요약 길이 경고 (30자 이내 권장)
+TITLE_SUMMARY=$(echo "$TITLE" | sed -E 's/^(([[:graph:]]{1,3})\s*)?[A-Z][a-zA-Z]+\.\s*//')
+TITLE_LENGTH=$(echo -n "$TITLE_SUMMARY" | wc -m)
+
+if [ "$TITLE_LENGTH" -gt 30 ]; then
+  echo "⚠️ 제목 요약이 $TITLE_LENGTH자입니다 (30자 이내 권장)"
+fi
+
+# ✅ 본문 검사 (Why, How 필수)
+if ! grep -q "^Why:" "$COMMIT_MSG_FILE" || \
+   ! grep -q "^How:" "$COMMIT_MSG_FILE"; then
+  echo "❌ 본문 누락: Why:, How: 섹션이 모두 포함되어야 합니다."
+  exit 1
+fi
+
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+echo "🔧 Husky 커밋 메시지 검사 환경 자동 설정 시작..."
+
+# ✅ 0. npm 명령어 유무 확인
+if ! command -v npm >/dev/null 2>&1; then
+  echo "❌ npm이 설치되어 있지 않습니다. 먼저 Node.js를 설치해주세요."
+  echo "   👉 macOS: brew install node"
+  echo "   👉 Windows: https://nodejs.org"
+  exit 1
+fi
+
+# 1. package.json 존재 여부 확인
+if [ ! -f package.json ]; then
+  echo "⚠️ package.json이 없습니다. 먼저 Node 프로젝트를 초기화해주세요: npm init -y"
+  exit 1
+fi
+
+# 2. Husky 설치
+echo "📦 husky 설치 중..."
+npm install husky --save-dev
+
+# 3. prepare 스크립트 추가 (기존에 없을 경우만)
+if ! grep -q '"prepare": "husky install"' package.json; then
+  echo "📄 package.json에 prepare 스크립트 추가..."
+  npm pkg set scripts.prepare="husky install"
+fi
+
+# 4. husky 초기화
+echo "🚀 husky install 실행 중..."
+npx husky install
+
+# 5. scripts 디렉토리 및 커밋 검사 스크립트 존재 확인
+HOOK_SCRIPT="scripts/validate-commit-msg.sh"
+if [ ! -f "$HOOK_SCRIPT" ]; then
+  echo "❌ $HOOK_SCRIPT 가 없습니다. 먼저 커밋 메시지 검사 스크립트를 작성해주세요."
+  exit 1
+fi
+
+# 6. .husky/commit-msg 파일 생성
+echo "🔗 .husky/commit-msg 설정 중..."
+mkdir -p .husky
+cat <<EOF > .husky/commit-msg
+#!/bin/sh
+bash $HOOK_SCRIPT "\$1"
+EOF
+chmod +x .husky/commit-msg
+
+# 7. 실행 권한 확인
+chmod +x "$HOOK_SCRIPT"
+
+# 8. 최종 확인
+echo "✅ setup 완료! 이제 커밋 메시지 검사 훅이 적용됩니다."
+echo "   테스트: git commit --allow-empty -m '잘못된 메시지'"


### PR DESCRIPTION
## About this PR

### ⚓ Related Issue
#37

### 🥥 Contents
- Node 프로젝트 초기화 및 husky@9.1.7 devDependency 추가
- `"prepare": "husky install"` 스크립트로 자동 훅 설정
- `.husky/commit-msg` 훅 → `validate-commit-msg.sh` 연동
- 커밋 메시지 규칙(제목·Why·How) 정규식 검증 로직 구현
- `setup.sh` 제공: 최초 실행 시 전체 절차 자동화
- `docs/commit-guide.md` 추가: 팀 규칙·예시·비활성화 방법 정리
- `.gitignore`에 node_modules/ 포함

### 📸 Screenshot
<!-- UI 변경이 없으므로 스크린샷 생략 -->

### 🚨 Checklist
- [x] 관련 이슈와 연결되었나요?
- [x] 빌드/테스트는 통과하였나요?
- [x] README·문서가 최신 상태인가요?

### 💬 Other information
- 로컬 훅이므로 CI 환경에서는 동작하지 않습니다.
- 규칙 예외가 필요하면 `validate-commit-msg.sh` 예외 섹션을 수정해 주세요.