### PR TITLE
✨ Feat. HealthKit 수영 데이터 연동

### DIFF
--- a/UmpahUmpah.xcodeproj/project.pbxproj
+++ b/UmpahUmpah.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = UmpahUmpah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = UmpahProfile;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = UmpahDevelopmentProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -378,6 +379,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = UmpahUmpah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = UmpahProfile;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = UmpahDevelopmentProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/UmpahUmpah/ContentView.swift
+++ b/UmpahUmpah/ContentView.swift
@@ -32,6 +32,11 @@ struct ContentView: View {
                         Label("Add Item", systemImage: "plus")
                     }
                 }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    NavigationLink(destination: SettingView()) {
+                        Image(systemName: "gearshape")
+                    }
+                }
             }
         } detail: {
             Text("Select an item")

--- a/UmpahUmpah/HealthStore.swift
+++ b/UmpahUmpah/HealthStore.swift
@@ -1,0 +1,94 @@
+import HealthKit
+
+public final class HealthStore {
+    private let healthStore = HKHealthStore()
+
+    // MARK: - 권한 요청
+
+    func requestAuthorization(completion: @escaping (Bool, Error?) -> Void) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            completion(false, nil)
+            return
+        }
+        let readTypes: Set<HKObjectType> = [
+            HKObjectType.workoutType(),
+            HKObjectType.quantityType(forIdentifier: .distanceSwimming)!,
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            HKObjectType.quantityType(forIdentifier: .heartRate)!,
+        ]
+        healthStore.requestAuthorization(toShare: nil, read: readTypes, completion: completion)
+    }
+
+    // MARK: - 수영 운동 데이터 조회
+
+    func fetchSwimmingWorkouts(completion: @escaping ([HKWorkout]) -> Void) {
+        let workoutPredicate = HKQuery.predicateForWorkouts(with: .swimming)
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+        let query = HKSampleQuery(
+            sampleType: .workoutType(),
+            predicate: workoutPredicate,
+            limit: 10,
+            sortDescriptors: [sortDescriptor]
+        ) { _, samples, error in
+            guard error == nil, let workouts = samples as? [HKWorkout] else {
+                completion([])
+                return
+            }
+            completion(workouts)
+        }
+        healthStore.execute(query)
+    }
+
+    // MARK: - 통계형 데이터 조회 (ex. 칼로리, 거리, 심박수)
+
+    func fetchQuantityStats(
+        typeIdentifier: HKQuantityTypeIdentifier,
+        startDate: Date,
+        endDate: Date,
+        unit: HKUnit,
+        completion: @escaping (Double?) -> Void
+    ) {
+        guard let quantityType = HKObjectType.quantityType(forIdentifier: typeIdentifier) else {
+            completion(nil)
+            return
+        }
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
+        let query = HKStatisticsQuery(quantityType: quantityType, quantitySamplePredicate: predicate, options: [.cumulativeSum]) { _, statistics, _ in
+            let value = statistics?.sumQuantity()?.doubleValue(for: unit)
+            completion(value)
+        }
+        healthStore.execute(query)
+    }
+
+    // MARK: - 심박수 샘플 조회
+
+    func fetchHeartRateSamples(startDate: Date, endDate: Date, completion: @escaping ([HKQuantitySample]) -> Void) {
+        guard let heartRateType = HKObjectType.quantityType(forIdentifier: .heartRate) else {
+            completion([])
+            return
+        }
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
+        let query = HKSampleQuery(sampleType: heartRateType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: nil) { _, samples, _ in
+            let heartRates = samples as? [HKQuantitySample] ?? []
+            completion(heartRates)
+        }
+        healthStore.execute(query)
+    }
+
+    // MARK: - 평균 페이스, 랩수, SWOLF 계산 (향후 구현 예정)
+
+    func calculateAveragePace(distance _: Double, duration _: Double) -> Double? {
+        // TODO: 평균 페이스 계산 로직 구현 예정
+        return nil
+    }
+
+    func calculateLapCount( /* 필요한 파라미터 */ ) -> Int? {
+        // TODO: 랩수 계산 로직 구현 예정
+        return nil
+    }
+
+    func calculateSwolf( /* 필요한 파라미터 */ ) -> Double? {
+        // TODO: SWOLF 지수 계산 로직 구현 예정
+        return nil
+    }
+}

--- a/UmpahUmpah/Info.plist
+++ b/UmpahUmpah/Info.plist
@@ -6,5 +6,9 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>건강 정보 업데이트 때문에 앱에 대한 권한 요청을 합니다.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>건강 정보 공유 때문에 앱에 대한 권한을 요청합니다.</string>
 </dict>
 </plist>

--- a/UmpahUmpah/SettingView.swift
+++ b/UmpahUmpah/SettingView.swift
@@ -1,0 +1,186 @@
+import Foundation
+import HealthKit
+import SwiftData
+import SwiftUI
+
+enum HealthKitAuthState {
+    case unknown
+    case authorized
+    case denied
+}
+
+struct SettingView: View {
+    @State private var swimmingData: [String: Any] = [:]
+    @State private var selectedDate: Date = .init()
+    @State private var healthKitAuthState: HealthKitAuthState = .unknown
+    @AppStorage("isHealthKitEnabled") private var isHealthKitEnabled: Bool = true
+
+    let healthStore = HealthStore()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            switch healthKitAuthState {
+            case .unknown:
+                ProgressView("HealthKit 권한 확인 중...")
+
+            case .denied:
+                VStack(spacing: 16) {
+                    Image(systemName: "heart.slash.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(.red)
+                    Text("HealthKit 접근 권한이 필요합니다.")
+                        .font(.title3)
+                        .multilineTextAlignment(.center)
+                    Button("권한 요청하기") {
+                        requestHealthKitAccess()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.pink)
+                    Text("요청 중 문제가 발생했거나 접근이 거부되었습니다.\n설정 앱에서 권한을 수동으로 허용해주세요.")
+                        .foregroundColor(.red)
+                        .font(.footnote)
+                        .multilineTextAlignment(.center)
+                }
+
+            case .authorized:
+                VStack(spacing: 24) {
+                    Toggle(isOn: $isHealthKitEnabled) {
+                        Label("HealthKit 데이터 사용", systemImage: "heart.fill")
+                    }
+                    .toggleStyle(.switch)
+                    .tint(.green)
+
+                    // 캘린더 항상 노출
+                    DatePicker("날짜 선택", selection: $selectedDate, displayedComponents: .date)
+                        .datePickerStyle(.graphical)
+                        .padding(.horizontal)
+
+                    if isHealthKitEnabled {
+                        // 조회된 날짜 표시
+                        Text("\(selectedDate, formatter: dateFormatter) 수영 데이터")
+                            .font(.title2)
+
+                        if !swimmingData.isEmpty, swimmingData.values.contains(where: { ($0 as? Double ?? 0) > 0 }) {
+                            VStack(alignment: .leading, spacing: 8) {
+                                if let duration = swimmingData["duration"] as? Double {
+                                    let totalSeconds = Int(duration)
+                                    let hours = totalSeconds / 3600
+                                    let minutes = (totalSeconds % 3600) / 60
+                                    if hours > 0 {
+                                        Text("운동시간: \(hours)시간 \(minutes)분")
+                                    } else {
+                                        Text("운동시간: \(minutes)분")
+                                    }
+                                }
+                                if let distance = swimmingData["workoutDistance"] as? Double {
+                                    Text("총 거리: \(distance, specifier: "%.2f") m")
+                                }
+                                if let calories = swimmingData["workoutCalories"] as? Double {
+                                    Text("칼로리: \(calories, specifier: "%.0f") kcal")
+                                }
+                                if let heartRate = swimmingData["heartRate"] as? Double {
+                                    Text("평균 심박수: \(heartRate, specifier: "%.0f") bpm")
+                                }
+                                // 평균 페이스, 랩수, SWOLF(향후 구현 예정)
+                                if swimmingData["avgPace"] != nil {
+                                    // TODO: 평균 페이스 계산 및 표시 구현 예정
+                                    Text("평균 페이스: (추후 구현)")
+                                }
+                                if swimmingData["lapCount"] != nil {
+                                    // TODO: 랩수 계산 및 표시 구현 예정
+                                    Text("랩 수: (추후 구현)")
+                                }
+                                if swimmingData["swolf"] != nil {
+                                    // TODO: SWOLF 지수 계산 및 표시 구현 예정
+                                    Text("SWOLF: (추후 구현)")
+                                }
+                            }
+                            .padding(.top, 8)
+                        } else {
+                            Text("해당 날짜의 수영 데이터가 없습니다.")
+                                .foregroundColor(.gray)
+                        }
+                    } else {
+                        Text("HealthKit 사용이 비활성화되었습니다.\n데이터를 조회하려면 토글을 켜주세요.")
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.gray)
+                            .padding()
+                    }
+                }
+            }
+        }
+        .padding()
+        .onAppear {
+            requestHealthKitAccess()
+            fetchSwimmingDataForSelectedDate()
+        }
+        .onChange(of: selectedDate) {
+            fetchSwimmingDataForSelectedDate()
+        }
+    }
+
+    func requestHealthKitAccess() {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            healthKitAuthState = .denied
+            return
+        }
+        healthStore.requestAuthorization { success, _ in
+            DispatchQueue.main.async {
+                healthKitAuthState = success ? .authorized : .denied
+            }
+        }
+    }
+
+    func fetchSwimmingDataForSelectedDate() {
+        let start = Calendar.current.startOfDay(for: selectedDate)
+        let end = Calendar.current.date(byAdding: .day, value: 1, to: start) ?? start
+        swimmingData = [:]
+        healthStore.fetchSwimmingWorkouts { workouts in
+            // 선택한 날짜의 workout 중 가장 최근 것만 사용
+            guard let workout = workouts.first(where: { $0.startDate >= start && $0.startDate < end }) else {
+                DispatchQueue.main.async {
+                    swimmingData = [:]
+                }
+                return
+            }
+            let duration = workout.duration
+            let distance = workout.totalDistance?.doubleValue(for: .meter()) ?? 0
+//            let lapCount = Double(workout.lapCount)
+            var result: [String: Any] = [
+                "duration": duration,
+                "workoutDistance": distance,
+//                "lapCount": lapCount
+            ]
+            let group = DispatchGroup()
+            // 칼로리
+            group.enter()
+            healthStore.fetchQuantityStats(typeIdentifier: .activeEnergyBurned, startDate: workout.startDate, endDate: workout.endDate, unit: .kilocalorie()) { calories in
+                if let calories = calories { result["workoutCalories"] = calories }
+                group.leave()
+            }
+            // 심박수
+            group.enter()
+            healthStore.fetchHeartRateSamples(startDate: workout.startDate, endDate: workout.endDate) { samples in
+                let avg = samples.map { $0.quantity.doubleValue(for: .init(from: "count/min")) }.average
+                if let avg = avg { result["heartRate"] = avg }
+                group.leave()
+            }
+
+            group.notify(queue: .main) {
+                swimmingData = result
+            }
+        }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }
+}
+
+// Double 배열 평균/합 extension
+private extension Array where Element == Double {
+    var average: Double? { isEmpty ? nil : reduce(0, +) / Double(count) }
+    var sum: Double? { isEmpty ? nil : reduce(0, +) }
+}

--- a/UmpahUmpah/UmpahUmpah.entitlements
+++ b/UmpahUmpah/UmpahUmpah.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array/>
 	<key>com.apple.developer.icloud-services</key>


### PR DESCRIPTION
## About this PR

### ⚓ Related Issue
- #50 

### 🥥 Contents
- HealthKit 권한 요청 기능 추가 (`HealthStore.swift`)
- 수영 운동(HKWorkout) 조회 및 통계 정보 fetch 로직 구현
- `SettingView.swift`에 날짜 선택 및 수영 정보 UI 추가
- Info.plist, entitlements에 HealthKit 관련 권한 설명 및 키 추가

### 📸 Screenshot
<!-- UI 확인을 위한 스크린샷 첨부 가능 -->
<img width="300" src="https://github.com/user-attachments/assets/527b5b6b-428e-4d40-8b00-20e0d53af927">
<img width="300" src="https://github.com/user-attachments/assets/d3a46ce2-305a-4177-846e-7fb5f0e6ab6c">
<img width="300" src="https://github.com/user-attachments/assets/94c09e95-a5a3-4a5d-9234-89bc8c05856a">

### 🚨 Checklist
- [x] 관련 이슈와 연결되었나요?
- [x] 빌드/테스트는 통과하였나요?
- [x] 필요한 문서가 있다면 작성하였나요?

### 💬 Other information

#### 🫀 HealthKit 통합 구조 요약

- HealthStore.swift는 HealthKit 데이터를 추상화한 계층
- SettingView.swift는 사용자 UI 및 날짜별 데이터 시각화 처리
- 운동 시간, 거리, 칼로리, 심박수 등 주요 지표를 수집 및 표시
- 평균 페이스, SWOLF, 랩 수 등은 Stub으로 후속 개발 예정

> HealthKit은 시뮬레이터에서 작동하지 않으므로 **실기기에서 테스트**해주세요