### PR TITLE
🎨 Design: #66 TripleGraphView UI 구조 분리 및 시각화 개선

### DIFF
--- a/UmpahUmpah/Presentation/Views/MainView/MainView.swift
+++ b/UmpahUmpah/Presentation/Views/MainView/MainView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainView: View {
     @StateObject private var viewModel = MainViewModel()
     @StateObject private var chartViewModel = ChartViewModel()
+
     @State private var isDataEmpty = false
 
     var body: some View {
@@ -18,16 +19,21 @@ struct MainView: View {
                 // MARK: Header Section
 
                 HeaderSectionView()
+
+                // MARK: WeeklyCalendarView Section
+
                 WeeklyCalendarView(viewModel: viewModel)
+
+                // MARK: SwimMetricGridView Section
 
                 if !isDataEmpty {
                     SwimMetricGridView(viewModel: chartViewModel)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 20)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 20)
                 } else {
                     Spacer()
                     Text("아직 수집된 데이터가 없어요!\n 설정에서 접근 권한을 확인해 주세요.")
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.system(size: 16, weight: .bold))
                         .foregroundColor(Color.subGray)
                         .multilineTextAlignment(.center)
                     Spacer()

--- a/UmpahUmpah/Presentation/Views/MainView/TripleGraphView.swift
+++ b/UmpahUmpah/Presentation/Views/MainView/TripleGraphView.swift
@@ -2,14 +2,9 @@ import SwiftUI
 
 struct TripleGraphView: View {
     @ObservedObject var viewModel: ChartViewModel
-
+    
     var body: some View {
         VStack(alignment: .leading) {
-            GraphRowView(
-                title: "스트로크 효율성",
-                value: viewModel.strokeEfficiency,
-                color: .graph1
-            )
             GraphRowView(
                 title: "안정지수",
                 value: viewModel.stability,
@@ -34,6 +29,7 @@ struct TripleGraphView: View {
                         .stroke(Color.white.opacity(0.12), lineWidth: 7)
                 )
         )
+        StrokeEfficiencyView(value: viewModel.strokeEfficiency)
     }
 }
 
@@ -41,10 +37,10 @@ private struct GraphRowView: View {
     let title: String
     let value: Double
     let color: Color
-
+    
     private let barHeight: CGFloat = 32
     private let maxWidth: CGFloat = 210
-
+    
     var body: some View {
         HStack {
             ZStack(alignment: .leading) {
@@ -52,7 +48,7 @@ private struct GraphRowView: View {
                     .fill(color)
                     .frame(width: CGFloat(value) * maxWidth, height: barHeight)
                     .cornerRadius(10, corners: [.topRight, .bottomRight])
-
+                
                 Text("\(Int(Double(value) * 100))")
                     .font(.system(size: 20, weight: .bold))
                     .foregroundColor(.white)
@@ -64,6 +60,41 @@ private struct GraphRowView: View {
                 .foregroundStyle(color)
         }
         .padding(.horizontal, 10)
+    }
+}
+
+private struct StrokeEfficiencyView: View {
+    let value: Double
+    
+    var body: some View {
+        HStack {
+            Text("\(value, specifier: "%.1f")")
+                .font(.system(size: 26, weight: .bold))
+                .foregroundColor(Color.graph1)
+                +
+                Text("m / stroke")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundColor(Color.graph1)
+
+            Spacer()
+            
+            Text("스트로크 효율성")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(Color.graph1)
+        }
+        
+        .padding(.horizontal, 22)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.white)
+                .shadow(color: .black.opacity(0.11), radius: 6, x: 0, y: 1)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .inset(by: 3.5)
+                        .stroke(Color.white.opacity(0.12), lineWidth: 7)
+                )
+        )
     }
 }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #66 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `TripleGraphView` 내 수치 지표와 그래프 지표 영역을 명확히 분리
- 수치 영역에는 스트로크 효율성 지표 표시
- 그래프 영역에는 안정 지수 및 몰입도 차트 구성
- 내부 UI 컴포넌트 분리 및 레이아웃 개선

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="546" alt="image" src="https://github.com/user-attachments/assets/f720c6b6-47f8-4044-97bd-917f7ac66c02" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] SwiftUI Preview 및 실제 런타임 모두 정상 작동
- [x]`TripleGraphView` 내 모든 영역 정상 렌더링 확인
- [x] 수치 데이터와 그래프 데이터가 레이아웃상 충돌 없이 분리됨

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
