### PR TITLE
🐛 Fix: #75 HealthKit 권한 요청 실패 해결

### DIFF
--- a/UmpahUmpah/Domain/HealthKitManager.swift
+++ b/UmpahUmpah/Domain/HealthKitManager.swift
@@ -62,11 +62,9 @@ final class HealthKitManager: ObservableObject {
     // MARK: - 타입 구성
 
     private func configureTypes() {
-        if let steps = HKObjectType.quantityType(forIdentifier: .stepCount),
-           let heart = HKObjectType.quantityType(forIdentifier: .heartRate)
-        {
-            readTypes = [steps, heart]
-            shareTypes = [steps, heart]
+        if let heart = HKObjectType.quantityType(forIdentifier: .heartRate) {
+            readTypes = [heart]
+            shareTypes = [heart]
         }
     }
 
@@ -106,7 +104,7 @@ final class HealthKitManager: ObservableObject {
         }
         do {
             try await healthStore.requestAuthorization(toShare: shareTypes,
-                                                       read: readTypes)
+                                                       read: swimmingTypes)
         } catch {
             // 사용자가 ‘취소’ 가능 – 오류 전파 없음 (기존 동작 유지)
         }
@@ -118,7 +116,7 @@ final class HealthKitManager: ObservableObject {
     //  - 기존 HealthKitManager 의 API와 동일: throws 로 오류 전달
     func requestSwimmingAuthorization() async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            healthStore.requestAuthorization(toShare: nil,
+            healthStore.requestAuthorization(toShare: shareTypes,
                                              read: swimmingTypes)
             { success, error in
                 if let error = error { continuation.resume(throwing: error) }


### PR DESCRIPTION
## About this PR

### ⚓ Related Issue
- #75 

### 🥥 Contents
- **configureTypes()**
  - `stepCount` 제거 → OS 호환성 문제 해결
  - `heartRate`만 read/share 세트에 추가
- **requestAuthorization()**
  - read 파라미터를 `swimmingTypes`로 수정해 수영 데이터 권한 정상 요청
- **requestSwimmingAuthorization()**
  - share 파라미터에 `shareTypes` 전달하여 쓰기 권한 요청 가능
- 모든 경로에서 권한 다이얼로그 호출 및 연동 토글 동작 확인

### 📸 Screenshot
<!-- 필요 시 HealthKit 다이얼로그 캡처 첨부 -->

### 🚨 Checklist
- [x] 시뮬레이터·실기기에서 권한 요청 정상 호출
- [x] 토글 ON/OFF 시 데이터 스트림 활성·비활성 확인
- [ ] 릴리즈 노트에 버그 수정 내역 추가