### PR TITLE
✨ Feat. 사용자 피드백 저장 및 로딩 기능 추가 #88

### DIFF
--- a/UmpahUmpah/Presentation/ViewModels/VSFeedbackViewModel.swift
+++ b/UmpahUmpah/Presentation/ViewModels/VSFeedbackViewModel.swift
@@ -20,7 +20,7 @@ final class VSFeedbackViewModel: ObservableObject {
         self.useCase = useCase
     }
     
-    /// 펼치기 전 사용량 제한 체크 
+    /// 펼치기 전 사용량 제한 체크
     func checkUsageLimit() -> Bool {
         // ChatGPTRepositoryImpl 직접 접근 (임시)
         let repository = ChatGPTRepositoryImpl()
@@ -45,6 +45,7 @@ final class VSFeedbackViewModel: ObservableObject {
             do {
                 let result = try await useCase.execute(from: dailyInfo)
                 feedback = result
+                saveFeedbackForToday(result)
             } catch let error as APILimitError {
                 // 사용량 제한 에러 처리
                 errorMessage = error.localizedDescription
@@ -56,6 +57,20 @@ final class VSFeedbackViewModel: ObservableObject {
             }
             
             isLoading = false
+        }
+    }
+    
+    private func saveFeedbackForToday(_ feedback: String) {
+        let today = Date().formattedTodayDate().replacingOccurrences(of: ".", with: "-")
+        let key = "feedback_\(today)"
+        UserDefaults.standard.set(feedback, forKey: key)
+    }
+
+    func loadTodayFeedback() {
+        let today = Date().formattedTodayDate().replacingOccurrences(of: ".", with: "-")
+        let key = "feedback_\(today)"
+        if let savedFeedback = UserDefaults.standard.string(forKey: key) {
+            feedback = savedFeedback
         }
     }
 }

--- a/UmpahUmpah/Presentation/Views/VSView/VSView.swift
+++ b/UmpahUmpah/Presentation/Views/VSView/VSView.swift
@@ -5,7 +5,7 @@ struct VSView: View {
         useCase: RequestFeedbackUseCaseImpl(repository: ChatGPTRepositoryImpl())
     )
     @EnvironmentObject var swimmingStatsViewModel: SwimmingStatsViewModel
-    
+
     // API 테스트용 목업 데이터
     private var mockDailyInfo: DailySwimmingInfo {
         let mockWorkout = SwimmingWorkout(
@@ -17,19 +17,19 @@ struct VSView: View {
             energy: 450, // 450kcal
             lapCount: 30
         )
-        
+
         let mockScore = SwimmingScore(
             stabilityScore: 85.5,
             strokeEfficiency: 2.1,
             immersionScore: 78.3
         )
-        
+
         let mockHeartRates = [
             HeartRateSample(bpm: 140, date: Date().addingTimeInterval(-1800)),
             HeartRateSample(bpm: 150, date: Date().addingTimeInterval(-900)),
             HeartRateSample(bpm: 145, date: Date())
         ]
-        
+
         let mockStrokeInfos = [
             StrokeInfo(
                 start: Date().addingTimeInterval(-3600),
@@ -38,7 +38,7 @@ struct VSView: View {
                 style: .freestyle
             )
         ]
-        
+
         return DailySwimmingInfo(
             date: Calendar.current.startOfDay(for: Date()),
             workout: mockWorkout,
@@ -60,7 +60,7 @@ struct VSView: View {
 
                 // 실제 데이터가 있으면 사용, 없으면 목업 데이터 사용
                 let dailyInfo = swimmingStatsViewModel.currentDailyInfo ?? mockDailyInfo
-                
+
                 ExpandableBox(
                     viewModel: viewModel,
                     swimData: dailyInfo
@@ -75,6 +75,9 @@ struct VSView: View {
 
                 .padding(.vertical, 10)
                 .padding(.horizontal)
+            }
+            .onAppear {
+                viewModel.loadTodayFeedback()
             }
         }
         .ignoresSafeArea()


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #88 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `VSFeedbackViewModel`에 당일 피드백을 저장하는 `saveFeedbackForToday(_:)` 함수 추가
- - `VSFeedbackViewModel`에 당일 피드백을 불러오는 `loadTodayFeedback()` 함수 추가
- `UserDefaults`에 `"feedback_yyyy-MM-dd"` 형식으로 키를 생성해 저장
- `loadTodayFeedback()` 함수를 통해 저장된 피드백을 불러올 수 있도록 구현
- `VSView` 진입 시 `onAppear`에서 해당 피드백 자동 로딩 처리

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 당일 피드백 생성 후, 앱 종료해도 기존 피드백 불러오는 것 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 6월 6일 피드백을 불러오는건 확인했는데, 6월 7일(미래)가 됐을 때를 테스트 못해봤습니다..

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
